### PR TITLE
Tweak vehicles - M115 and MI8MT

### DIFF
--- a/Cherno 1990s/cherno90sblu/autogen.hpp
+++ b/Cherno 1990s/cherno90sblu/autogen.hpp
@@ -1800,6 +1800,8 @@ class CfgVehicles {
 
 
         class EventHandlers : EventHandlers {
+            postInit = "params ['_entity']; [_entity] enableInfoPanelComponent ['right', 'MinimapDisplay', false]; [_entity] enableInfoPanelComponent ['left', 'MinimapDisplay', false];";
+
             class CBA_Extended_EventHandlers : CBA_Extended_EventHandlers_base {};
 
             class ALiVE_orbatCreator {

--- a/Cherno 1990s/cherno90sblu/autogen.hpp
+++ b/Cherno 1990s/cherno90sblu/autogen.hpp
@@ -2146,6 +2146,7 @@ class CfgVehicles {
         side = 1;
         faction = "B_AFBiH";
         crew = "B_AFBiH_Pilot";
+        ace_cargo_space = 14;
 
         class Turrets : Turrets {
             class CopilotTurret : CopilotTurret { gunnerType = "B_AFBiH_Pilot"; };

--- a/Cherno 1990s/cherno90sopf/autogen.hpp
+++ b/Cherno 1990s/cherno90sopf/autogen.hpp
@@ -1565,6 +1565,7 @@ class CfgVehicles {
         side = 0;
         faction = "O_RSA90";
         crew = "O_RSA90_Driver";
+        enableGPS = 0;
 
         class Turrets : Turrets {
             class GPK_Turret : GPK_Turret { gunnerType = "O_RSA90_Engineer"; };

--- a/Cherno 1990s/cherno90sopf/autogen.hpp
+++ b/Cherno 1990s/cherno90sopf/autogen.hpp
@@ -1919,6 +1919,7 @@ class CfgVehicles {
         side = 0;
         faction = "O_RSA90";
         crew = "O_RSA90_Pilot";
+        ace_cargo_space = 14;
 
         class Turrets : Turrets {
             class CopilotTurret : CopilotTurret { gunnerType = "O_RSA90_Pilot"; };


### PR DESCRIPTION
1. Disable GPS for blufor M1151 (via [postInit](https://community.bistudio.com/wiki/enableInfoPanelComponent)) - I don't like this version but it works locally + is recommended by people on forums + biki so I'm inclined to use it as a fallback if other options fail on dedicated
2. Disable GPS for opfor M1151 (via [enableGPS](https://community.bistudio.com/wiki/CfgVehicles_Config_Reference#enableGPS)) - this seems more elegant
3. Set ACE Cargo size for blufor and opfor variants of MI8MT_Cargo - set to 14

Regarding 1 and 2 - I also tried to disable the GPS component panel by fiddling with inherited component classes, but encountered some problems. Since wiki doesn't present a straightforward way to disable it within the component class I abandoned the attempts - but that'd be a pretty cool solution :C